### PR TITLE
Fix: fetches recently added listings to highlighted listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,11 @@
           </div>
 
           <div class="text-right">
-            <a href="/listings/" class="font-heading text-lg text-right"
-              >View All</a
-            >
+            <a
+              href="/listings/"
+              class="font-heading font-bold text-lg text-right"
+              >View All ->
+            </a>
           </div>
         </div>
       </section>

--- a/src/js/pages/homepage.js
+++ b/src/js/pages/homepage.js
@@ -50,6 +50,8 @@ async function loadHighlightedListings() {
       page: 1,
       limit: 4,
       active: true,
+      sort: "created",
+      order: "desc",
     });
 
     if (data && data.length > 0) {


### PR DESCRIPTION
This PR updates "Highlighted Listings" on the home page to fetch and display the four most recently added listings. 